### PR TITLE
Debian doesn’t provide apt-transport-https by default

### DIFF
--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -1,4 +1,9 @@
 ---
+- name: debian | install apt-transport-https
+  apt:
+    name: apt-transport-https
+    state: present
+
 - name: debian | adding nodejs repo key
   apt_key:
     id: "{{ nodejs_debian_repo_info.id }}"


### PR DESCRIPTION
Hi,
On a fresh debian 8 install you will need to install `apt-transport-https` before adding nodejs repo.